### PR TITLE
Updates to DET1 spec stuff

### DIFF
--- a/notebooks/StraylightWrapperExample.ipynb
+++ b/notebooks/StraylightWrapperExample.ipynb
@@ -41,6 +41,9 @@
     "obs = info.Observation(seqid=seqid)\n",
     "obs = info.Observation(path=f'{top}/data/', seqid=seqid)\n",
     "\n",
+    "# Point to the location where you want to store your results\n",
+    "obs.set_outpath=here+'/10402004004/products'\n",
+    "\n",
     "print(obs._evtfiles['B'][0])\n",
     "# Spawns an Xselect instance behind the scenes. Output in the same place as the event data\n",
     "det1B_file = wrappers.make_det1_image(obs._evtfiles['B'][0],elow=3, ehigh=20)\n",
@@ -67,7 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Go make the region file using ds9. Make sure to to use \n",
+    "# Go make the region file using ds9. This spawns an XSELECT run behind the scenes, so\n",
+    "# you'll need to wait for this complete (usually pretty quick)\n",
     "reg_file = obs.path+'/'+obs.seqid+'/event_cl/srcB.reg'\n",
     "filt_file = wrappers.extract_det1_events(obs._evtfiles['B'][0], regfile=reg_file)\n",
     "\n",
@@ -78,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "4. Make a lightcurve script that spawns nuproducts. Note that we have turned off all of the nuproducts flags that cause it to apply the PSF, exposure, and vignetting corrections. This does do the livetime corrections. For straylight sources the motion of the telescope pointing/mast shouldn't affect the response of the instrument, and we'll assume that we'll take care of computing the effective area when doing spectroscopy. **Note:** this wrapper has a \"barycorr\" option, but it is currently disabled. If you're doing pulsar timing with stray light then you'll probably want to construct the nuproducts call yourself."
+    "4. Make a script to use nuproducts to produce a lightcurve. Note that we have turned off all of the nuproducts flags that cause it to apply the PSF, exposure, and vignetting corrections. This does do the livetime corrections. For straylight sources the motion of the telescope pointing/mast shouldn't affect the response of the instrument, and we'll assume that we'll take care of computing the effective area when doing spectroscopy. **Note:** this wrapper has a \"barycorr\" option, but it is currently disabled. If you're doing pulsar timing with stray light then you'll probably want to construct the nuproducts call yourself."
    ]
   },
   {
@@ -89,15 +93,16 @@
    "source": [
     "from astropy import units as u\n",
     "time_bin = 100*u.s\n",
-    "lc_script = wrappers.make_det1_lightcurve(filt_file, mod='B', elow=3, ehigh=10, time_bin=time_bin, outpath='./10202005004/products/')\n",
-    "# lc_script is now the path to the nuproducts script. Right now appears in the same location as the notebook."
+    "lc_script = wrappers.make_det1_lightcurve(filt_file, mod='B', elow=3, ehigh=10, time_bin=time_bin, outpath=obs.out_path)\n",
+    "# lc_script is now the path to the nuproducts script. It will be located wherever we set outpath, but if outpath is not set then defaults to the same location as the notebook.\n",
+    "# Go run this in the shell"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "5. Run the script right from the notebook if you'd like. We can use these notebook magic commands to set the environment variables so that nuproducts runs smoothly behind the scenes:"
+    "5. Make a script to use nuproducts to produce a spectrum. Right now, this does not do anything with the background and does not produce an ARF on its own (see below). It will produce an RMF that will automatically be loaded when you load the data into Xspec."
    ]
   },
   {
@@ -106,13 +111,47 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
+    "det1spec_script = wrappers.make_det1_spectra(filt_file, 'B', outpath=obs.out_path)\n",
+    "# det1spec_script is now the path to the nuproducts script. It will be located wherever we set outpath, but if outpath is not set then defaults to the same location as the notebook.\n",
+    "# Go run this in the shell"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "6. Make and ARF. This is done \"by hand\" for now. To do this you also need to make a DET1 exposure map first. The detector area that you're using is currently bookkept into the ARF itself (but maybe should move to the AREASCAL keyword in the PHA file). This script uses the number of observed counts on each detectors to load in the DETABS values from the CALDB and multiplies this onto a base ARF that describes the attenuationin the Be window above the detectors. The ARF needs to be loaded by hand when using Xspec, or you can go use the fmodhead FTOOL to adjust the ANCRFILE keyword"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expo_script = wrappers.make_exposure_map(obs, 'B', det_expo=True)\n",
+    "# lc_script is now the path to the nuexpomap script. It will be located wherever we set outpath, but if outpath is not set then\n",
+    "# defaults to the same location as the notebook. If det_expo=False then this produces a Sky exposure map rather than the DET1 exposure map.\n",
+    "# Go run this in the shell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You need to specify the location of the exposure map file produce by the script above:\n",
+    "expo = obs.out_path+'/nu10402004004B_det1_expo.fits'\n",
+    "utils.make_straylight_arf(expo, reg_file, filt_file, 'B', outpath=obs.out_path)\n",
+    "# This runs inline and produces an ARF in obs.out_path.\n",
     "\n",
-    "%env HEADASNOQUERY=\n",
-    "%env HEADASPROMPT=/dev/null\n",
-    "os.system('./'+lc_script)\n",
+    "# We're now ready for Xspec analysis.\n",
     "\n",
-    "# The lightcurve file and its associated .gif render will now be in the outpath location to be used for downstream analysis."
+    "# For convenience, you can go to obs.out_path and do something like this:\n",
+    "fthedit nu10402004004B01_cl_srcB_sr.pha[1] keyword=ANCRFILE operation=add value=nu10402004004B01_cl_srcB.arf \n",
+    "\n",
+    "# ... note that the [1] is required to hit the correct FITS extension in the PHA file"
    ]
   }
  ],

--- a/nustar_gen/utils.py
+++ b/nustar_gen/utils.py
@@ -22,6 +22,27 @@ def energy_to_chan(keV):
     '''
     return int((keV - 1.6) / 0.04)
 
+def chan_to_energy(chan):
+    '''
+    Convert NuSTAR PI channels to keV
+    keV = PI * 0.04 + 1.6
+    
+    keV = energy_to_chan(210)
+    
+    
+     Example
+    -------
+    >>> from nustar_gen.utils import chan_to_energy
+    >>> chan = chan_to_energy(210)
+    >>> np.isclose(chan, 10.)
+    True
+
+    '''
+    try:
+        en = [float(x) *  0.04 + 1.6 for x in chan]
+    except:
+        en = chan * 0.04 + 1.6
+    return en
 
 def make_usr_gti(input_gtis, outfile='usrgti.fits', **kwargs):
     '''
@@ -163,7 +184,8 @@ def make_straylight_arf(det1im, regfile, filt_file, mod, outpath=None):
     
     filt_file : str
         Full path to the DET1 screened event file (i.e. output of
-        nustar_gen.wrappers.extract_det1_events() ).
+        nustar_gen.wrappers.extract_det1_events() ). This is only used for pulling out
+        the exposure in straylight_area.
 
     mod : str
         'A' or 'B'


### PR DESCRIPTION
- Fixed how nuproducts is being run so that it now uses the region filtered FITS file as input (just like the DET1 lightcurve script does). This avoids issues with trying to use DET1 region files with nuproducts, which doesn't work.

- Added chan_to_energy method to utils

- Some docstring updates to be more clear about what happens when the ARF is generated.




- Updates to the StrayLight example notebook

- Now shows how to use this ARF generator. Also includes some fixed syntax.

