### PR TITLE
Fixed #33 and #34 and feature addition

### DIFF
--- a/nustar_gen/info.py
+++ b/nustar_gen/info.py
@@ -108,6 +108,54 @@ class NuSTAR():
         this_time = TimeDelta(met, format='sec', scale ='tt') + self.ref_epoch
         return this_time
 
+    def rate_conversion(self, rate, incident=False):
+        '''
+        Converts observed counts per second into an incident rate
+    
+        Parameters
+        ----------
+        rate: float
+            Unitless NuSTAR MET seconds.
+
+        Other Parameters
+        ----------------
+    
+        incident: boolean, optional, False
+            If False, converts between measured and incident rates
+            If True, converts between incident and measured rates.
+    
+        Returns
+        -------
+    
+        rate: float
+            Measured/incident rate if the incident parameters is False/True
+    
+        '''
+    # 
+    #     Examples
+    #     --------
+    #     >>> ns = NuSTAR()
+    #     >>> met = 315578085.0
+    #     >>> time = ns.met_to_time(met)
+    #     >>> print(time.fits)
+    #     2020-01-01T12:34:42.000
+    #     
+    #     
+    # 
+    #     
+    
+
+        # Rate conversions from Gnoll, which basically say that any time you measure a
+        # count you induce 2.5 ms of livetime losses.
+
+        
+        if incident is True:
+            # Convert from incident to meaured rate
+           result = rate / (1.0 + rate * 2.5e-3)
+        else:
+            # Convert from measured to incident rate
+            result = rate / (1.0 - rate * 2.5e-3)
+        return result
 
 
 

--- a/nustar_gen/utils.py
+++ b/nustar_gen/utils.py
@@ -347,9 +347,23 @@ def validate_det1_region(regfile):
     """
     err=-1
     from regions.io.ds9.read import DS9Parser
-    assert os.path.isfile(regfile), f'{regilfe} does not exist!'
+    from regions import read_ds9
+    assert os.path.isfile(regfile), f'{regfile} does not exist!'
     
     with open(regfile) as fh: 
         region_string = fh.read()
     parser = DS9Parser(region_string)
-    assert parser.coordsys == 'image', f'Region coordinate system is {parser.coordsys}, not image!'
+    assert parser.coordsys == 'image', \
+        f'Region coordinate system is {parser.coordsys}, not image!'
+
+    # Check to make sure tha the first region in the file is an "include" region
+    reg = read_ds9(regfile)
+    for ri in reg:
+        assert ri.meta['include'] is True, \
+            f'\n {regfile} has an exclusion region first! \n Put the source region first instead!'
+
+
+    
+    
+
+


### PR DESCRIPTION
Fixes the normalization of the DET1 ARFs by doing the masking by hand (rather than using infrastructure from region since it seems to be broken for compound regions). This should close #33

Adds a check to make sure the include region is first (and not the exclusion region). This should close #34 

Added a measured-->throughput rate converter to the info.NuSTAR() class for convenience.