### PR TITLE
Update to wrappers.py

### DIFF
--- a/nustar_gen/utils.py
+++ b/nustar_gen/utils.py
@@ -361,6 +361,7 @@ def validate_det1_region(regfile):
     for ri in reg:
         assert ri.meta['include'] is True, \
             f'\n {regfile} has an exclusion region first! \n Put the source region first instead!'
+        break
 
 
     


### PR DESCRIPTION
Removes barycorr option and allows for gti input for the DET1 lightcurve wrapper. 