### PR TITLE
Wrapper update

### DIFF
--- a/notebooks/StraylightWrapperExample.ipynb
+++ b/notebooks/StraylightWrapperExample.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,13 +31,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "# top == some path to your top level data directory. \n",
     "here = os.getcwd()+'/'\n",
-    "\n",
     "obs = info.Observation(seqid='10202005004', path=here, out_path='./10202005004/products/')\n",
     "\n",
     "# Below spawns an Xselect instance behind the scenes.\n",
@@ -63,16 +62,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/bwgref/science/gs1826_stray/10202005004/event_cl/nu10202005004B01_cl_srcB.evt\n"
+     ]
+    }
+   ],
    "source": [
     "# Go make the region file using ds9.\n",
     "# Below spawns another XSELECT run behind the scenes to apply the region filtering in DET1 coordinates\n",
     "\n",
     "reg_file = obs.path+'/'+obs.seqid+'/event_cl/srcB.reg'\n",
     "filt_file = wrappers.extract_det1_events(obs.evtfiles['B'][0], regfile=reg_file)\n",
-    "\n",
+    "print(filt_file)\n",
     "# filt_file is now the full path to the extracted event file. This is located in obs.evdir by default."
    ]
   },
@@ -85,16 +92,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/bwgref/science/gs1826_stray/10202005004/products/rundet1lc_nu10202005004B01_full_FoV_3to10_100s.sh\n"
+     ]
+    }
+   ],
    "source": [
     "from astropy import units as u\n",
     "time_bin = 100*u.s\n",
     "lc_script = wrappers.make_det1_lightcurve(filt_file, mod='B', elow=3, ehigh=10, time_bin=time_bin, obs=obs)\n",
     "# lc_script is now the path to the nuproducts script to produce a lightcurve, which is stored in obs.out_path.\n",
     "#\n",
-    "# Go run ths in the shell"
+    "# Go run this in the shell\n",
+    "print(lc_script)"
    ]
   },
   {
@@ -106,14 +122,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/bwgref/science/gs1826_stray/10202005004/products/rundet1spec_nu10202005004B01_cl_srcB.sh\n"
+     ]
+    }
+   ],
    "source": [
     "det1spec_script = wrappers.make_det1_spectra(filt_file, 'B', obs=obs)\n",
     "# lc_script is now the path to the nuproducts script to produce a spectrum, which is stored in obs.out_path.\n",
     "#\n",
-    "# Go run ths in the shell"
+    "# Go run ths in the shell\n",
+    "print(det1spec_script)"
    ]
   },
   {
@@ -125,48 +150,119 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/bwgref/science/gs1826_stray/10202005004/products/runexpo_10202005004B.sh\n"
+     ]
+    }
+   ],
    "source": [
-    "expo_script = wrappers.make_exposure_map(obs, mod, det_expo=True)\n",
+    "expo_script = wrappers.make_exposure_map(obs, 'B', det_expo=True)\n",
     "\n",
     "# expo_script is now the path to the nuexpomap script, which is stored in obs.out_path.\n",
     "#\n",
     "# If det_expo=False then this produces a Sky exposure map rather than the DET1 exposure map.\n",
     "#\n",
-    "# Go run this in the shell"
+    "# Go run this in the shell\n",
+    "print(expo_script)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/bwgref/science/local/CALDB\n",
+      "Straylight area:     7.91 cm2\n"
+     ]
+    }
+   ],
    "source": [
     "# You need to specify the location of the exposure map file produce by the script above:\n",
-    "\n",
-    "det1expo = f'{obs.out_path}/nu{obs.seqid}{mod}_det1_expo.fits'\n",
-    "filt_ev = obs.evdir+f'/nu{obs.seqid}{mod}01_cl_src{mod}.evt'    \n",
-    "reg_file = obs.evdir+f'/src{mod}.reg'    \n",
+    "mod = 'B'\n",
+    "det1expo = os.path.join(obs.out_path, f'nu{obs.seqid}{mod}_det1_expo.fits')\n",
+    "filt_ev = os.path.join(obs.evdir, f'nu{obs.seqid}{mod}01_cl_src{mod}.evt')\n",
+    "reg_file = os.path.join(obs.evdir, f'src{mod}.reg')\n",
     "utils.make_straylight_arf(det1expo, reg_file, filt_ev, mod, obs=obs)\n",
     "\n",
     "# This produces an ARF in obs.out_path\n",
+    "\n",
+    "# You also need to know what the illuminated area is. Do that here:\n",
+    "area = utils.straylight_area(det1expo, reg_file, filt_ev)\n",
+    "print(f'Straylight area: {area:8.2f}')\n",
+    "\n",
+    "\n",
     "\n",
     "# We're now ready for Xspec analysis, but you will need to load the ARF by hand after loading in the data."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial BACKSCAL value is meaninglss: 0.280872\n",
+      "Confirm updated BACKSCAL value: 7.914544814048287\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: VerifyWarning: Card is too long, comment will be truncated. [astropy.io.fits.card]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Finally, we want to update a few header keywords to make things work.\n",
+    "\n",
+    "from astropy.io.fits import setval, getval\n",
+    "\n",
+    "# Set your PHA file here:\n",
+    "pha_file = os.path.join(obs.out_path, 'nu10202005004B01_cl_srcB_sr.pha')\n",
+    "\n",
+    "# Target the SPECTRUM extension (which is #1) \n",
+    "ext=1\n",
+    "backscal = getval(pha_file, 'BACKSCAL', ext=ext)\n",
+    "print(f'Initial BACKSCAL value is meaninglss: {backscal}')\n",
+    "\n",
+    "# Update it to be your straylight area value:\n",
+    "setval(pha_file, 'BACKSCAL', value=area.value, ext=ext)\n",
+    "\n",
+    "backscal = getval(pha_file, 'BACKSCAL', ext=ext)\n",
+    "print(f'Confirm updated BACKSCAL value: {backscal}')\n",
+    "\n",
+    "# Now also add on the ANCRFILE to point at the ARF:\n",
+    "# **NOTE** Figure out whether or not you want to have this be a realtive path or the *absolute* path to\n",
+    "# the ARF file\n",
+    "\n",
+    "arf_file = 'nu10202005004B01_cl_srcB.arf'\n",
+    "# Update it to be your straylight area:\n",
+    "setval(pha_file, 'ANCRFILE', value=arf_file, ext=ext)\n",
+    "\n",
+    "# You should be able to load things into Xspec now."
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# For convenience, in the shell you can go to obs.out_path and do something like the following using the fthedit FTOOL in HEASoft:\n",
-    "\n",
-    "fthedit nu10202005004B01_cl_srcB_sr.pha[1] keyword=ANCRFILE operation=add value=nu10202005004B01_cl_srcB.arf \n",
-    "\n",
-    "# ... note that the [1] is required to hit the correct FITS extension in the PHA file"
+    "# Still to be shown: How to do background subtraction!!"
    ]
   }
  ],

--- a/nustar_gen/info.py
+++ b/nustar_gen/info.py
@@ -199,6 +199,7 @@ class Observation():
         self._evdir_lock=False
         # If you specify the evdir location, make sure nothing can change this
         if evdir is not False:
+            evdir = os.path.absdir(evdir)
             self._set_evdir(evdir, lock=True)
             
         if seqid is False:
@@ -210,6 +211,7 @@ class Observation():
         if out_path is False:
             self.set_outpath(self.evdir)
         else:
+            out_path = os.path.abspath(out_path)
             self.set_outpath(out_path)
 
 
@@ -217,8 +219,9 @@ class Observation():
         '''
         Sets the path. Makes sure that path ends with a '/'
         '''
-        if not path.endswith('/'):
-            path +='/'
+        path = os.path.abspath(path)
+#         if not path.endswith('/'):
+#             path +='/'
         self._path = path
         return
     
@@ -347,7 +350,7 @@ class Observation():
         self._seqid=value
         
         
-        self._set_datapath(self._path+self._seqid)
+        self._set_datapath(os.path.join(self._path, self._seqid))
         
         # Set subdirectories
         self._hkdir=self._datapath+'/hk/'

--- a/nustar_gen/wrappers.py
+++ b/nustar_gen/wrappers.py
@@ -297,7 +297,7 @@ def make_image(infile, elow = 3, ehigh = 20, clobber=True, outpath=False, usrgti
     Parameters
     ----------
     infile: str
-        Full path tot eh file that you want to process
+        Full path to the file that you want to process
     elow: float
         Low-energy band for the image
     ehigh: float
@@ -356,7 +356,7 @@ def make_image(infile, elow = 3, ehigh = 20, clobber=True, outpath=False, usrgti
 
     
     # Generate outfile name
-    outfile = outdir+sname+f'_{elow}to{ehigh}keV.fits'
+    outfile = outdir+'/'+sname+f'_{elow}to{ehigh}keV.fits'
     
     if (os.path.exists(outfile)) & (~clobber):
         warnings.warn('make_image: %s exists, use clobber=True to regenerate' % (outfile))

--- a/nustar_gen/wrappers.py
+++ b/nustar_gen/wrappers.py
@@ -271,7 +271,6 @@ def make_exposure_map(obs, mod, vign_energy = False,
     
     
     # Construct the nuexpomap call:
-    print(obs.seqid, mod)
     expo_script = os.path.join(obs.out_path, 'runexpo_'+obs.seqid+mod+'.sh')
     expo = open(expo_script, 'w')
     


### PR DESCRIPTION
Should close #50 and #38 with the updates to the Obs class.

StrayLight Wrapper notebook now has a full end-to-end run that I tested locally, so that you should be able to just kick start Xspec.

The one thing that's still missing there is what to do with a background file. But I think that's a separable problem and we'll address it in another update.