### PR TITLE
Observation class definition updates

### DIFF
--- a/nustar_gen/info.py
+++ b/nustar_gen/info.py
@@ -190,13 +190,21 @@ class Observation():
         
     def __init__(self, path='./', seqid=False, evdir=False,
                 out_path=False):
+                                
         self.set_path(path)
-#        self._path=path
+
+        if out_path is False:
+            self.set_outpath(self.evdir)
+        else:
+            out_path = os.path.abspath(out_path)
+            self.set_outpath(out_path)
+
         self.modules = ['A', 'B']
         
         self._datapath = False
         
         self._evdir_lock=False
+
         # If you specify the evdir location, make sure nothing can change this
         if evdir is not False:
             evdir = os.path.abspath(evdir)
@@ -206,13 +214,6 @@ class Observation():
             self._seqid=False
         else:
             self._set_seqid(seqid)
-
-
-        if out_path is False:
-            self.set_outpath(self.evdir)
-        else:
-            out_path = os.path.abspath(out_path)
-            self.set_outpath(out_path)
 
 
     def set_path(self, path):
@@ -236,16 +237,6 @@ class Observation():
         
         return self._path
 
-
-    
-    def _set_datapath(self, value):
-        '''
-        Set the output path.
-        '''
-        self._datapath=value
-        assert os.path.isdir(self._datapath), f"Output path does not exist! {self._datapath})"
-        
-        return
     @property
     def observation_date(self):
         '''
@@ -256,7 +247,7 @@ class Observation():
 
     def _set_evdir(self, value, lock=False):
         '''
-        Set the output path.
+        Set the event directory.
         '''
         
         if self._evdir_lock is False:
@@ -287,15 +278,7 @@ class Observation():
         Returns an dict (with 'A' and 'B' as keys) with lists of exposures for
         all event files.
         '''
-        return self._exposure
-    
-    @property
-    def datapath(self):
-        '''
-        Returns the path to the data directory
-        '''
-        return self._datapath
-        
+        return self._exposure        
     
     @property
     def source_position(self):
@@ -349,15 +332,9 @@ class Observation():
         
         self._seqid=value
         
-        
-        self._set_datapath(os.path.join(self._path, self._seqid))
-        
-        # Set subdirectories
-        self._hkdir=self._datapath+'/hk/'
-        self._auxdir=self._datapath+'/auxil/'
-
         if self._evdir_lock is False:
             self._set_evdir(self._datapath+'/event_cl/')
+
 
         
         # Check to make sure this exiss:

--- a/nustar_gen/wrappers.py
+++ b/nustar_gen/wrappers.py
@@ -164,7 +164,7 @@ def make_lightcurve(infile, mod, src_reg,
     assert os.path.isfile(infile), 'make_lightcurve: infile does not exist!'
     assert os.path.isfile(src_reg), 'make_lightcurve: src_reg does not exist!'
 
-    assert time_bin.to(u.s) > 1*u.s, f'make_lightcurve: {time_bin} too fast, use another tool.'
+    assert time_bin.to(u.s) >= 1*u.s, f'make_lightcurve: {time_bin} too fast, use another tool.'
 
     if bgd_reg != 'None':
         assert os.path.isfile(bgd_reg), 'make_lightcurve: bgd_reg does not exist!'
@@ -960,7 +960,7 @@ def make_det1_lightcurve(infile, mod, obs,
     
     assert os.path.isfile(infile), 'make_det1_lightcurve: infile does not exist!'
 
-    assert time_bin.to(u.s) > 1*u.s, f'make_det1_lightcurve: time_bin {time_bin} too fast, use another tool.'
+    assert time_bin.to(u.s) >= 1*u.s, f'make_det1_lightcurve: time_bin {time_bin} too fast, use another tool.'
 
     evdir = obs.evdir
     seqid = obs.seqid


### PR DESCRIPTION
Addresses #68. Remove an issue where Observation was still looking for the data in a directory like:

./data/SEQID

This wasn't actually necessary and caused a conflict when you actually have the data in

./data/SEQID_NEW

or similar. New version removes the attribute "datapath" (unused) from the Observation class and should work.