### PR TITLE
Hotfix to auto-downgrade regions to v0.5

### DIFF
--- a/nustar_gen/version.py
+++ b/nustar_gen/version.py
@@ -5,4 +5,4 @@ try:
     from setuptools_scm import get_version
     version = get_version(root='..', relative_to=__file__)
 except Exception:
-    version = '0.6.dev0+gaac6164.d20220503'
+    version = '0.6.dev5+g39e065e.d20220616'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ h5py
 scikit-image
 sphinx
 sphinx_rtd_theme
-regions>=0.6
+regions==0.5


### PR DESCRIPTION
...until we figure out all of the metadata changes.

requirements now has ==0.5 for regions