### PR TITLE
fix bitwise operators

### DIFF
--- a/nustar_gen/info.py
+++ b/nustar_gen/info.py
@@ -312,8 +312,8 @@ class Observation():
         for mod in self.evtfiles:
             science_files[mod] = []
             for file in self.evtfiles[mod]:
-                if ( (f'{mod}01' in file) | (f'{mod}06' in file) ) &  \
-                    ( (file.endswith('gz') ) | \
+                if ( (f'{mod}01' in file) or (f'{mod}06' in file) ) and  \
+                    ( (file.endswith('gz') ) or \
                     (file.endswith('evt') ) ):
                     science_files[mod].extend([file])
             

--- a/nustar_gen/wrappers.py
+++ b/nustar_gen/wrappers.py
@@ -524,15 +524,16 @@ def extract_sky_events(infile, regfile, elow=1.6, ehigh=165., clobber=True, outp
     rname = os.path.splitext(rshort)[0]
     
     # Generate outfile name
-    if ( (elow == 1.6 ) & (ehigh==165.)):
+    if ( (elow == 1.6 ) and (ehigh==165.)):
         outfile = os.path.join(outdir, sname+f'_{rname}.evt')
     else:
         outfile = os.path.join(outdir, sname+f'_{elow}to{ehigh}_{rname}.evt')
 
-    if (os.path.exists(outfile)) & (~clobber):
-        warnings.warn('extract_sky_events: %s exists, use clobber=True to regenerate' % (outfile))
-    else:
-        os.system("rm "+outfile)
+    if (os.path.exists(outfile)):
+        if not clobber:
+            warnings.warn('extract_sky_events: %s exists, use clobber=True to regenerate' % (outfile))
+        else:
+            os.system("rm "+outfile)
     xsel_file = _make_xselect_commands_sky_evts(infile, outfile, 
                     regfile, elow, ehigh)
     os.system("xselect @"+xsel_file)
@@ -678,7 +679,7 @@ def apply_gti(infile, gtifile, clobber=True, outpath=False):
     outfile = os.path.join(outdir, sname+f'_{rname}.evt')
 
     if os.path.exists(outfile):
-        if ~clobber:
+        if not clobber:
             warnings.warn('apply_gti: %s exists, use clobber=True to regenerate' % (outfile))
         else:
             os.system("rm "+outfile)
@@ -959,13 +960,13 @@ def extract_det1_events(infile, regfile, elow=1.6, ehigh=165., clobber=True, out
     rname = os.path.splitext(rshort)[0]
     
     # Generate outfile name
-    if ( (elow == 1.6 ) & (ehigh==165.)):
+    if ( (elow == 1.6 ) and (ehigh==165.)):
         outfile = os.path.join(outdir, sname+f'_{rname}.evt')
     else:
         outfile = os.path.join(outdir, sname+f'_{elow}to{ehigh}_{rname}.evt')
 
     if (os.path.exists(outfile)):
-        if  (~clobber):
+        if not clobber:
             warnings.warn('extract_det1_events: %s exists, use clobber=True to regenerate' % (outfile))
         else:
             os.system("rm "+outfile)


### PR DESCRIPTION
>> Replaced all "~clobber" by "not clobber"
>> Changed the logic in wrappers.extract_sky_events function so it check if the outfile exists first before trying to remove it
>> Replaced some "|" and "&" operators by "or" and "and" to make it more concise
>> I noticed the wrappers._check_environment function also has an issue not raising the error when the environment variables are not set. But this is not due to the operators so I left it alone. I can submit a separate pull request to fix this if needed