### PR TITLE
Adds quality of life wrapper to write out ds9 region files

### DIFF
--- a/notebooks/OptimalRadius_Example.ipynb
+++ b/notebooks/OptimalRadius_Example.ipynb
@@ -21,13 +21,13 @@
    "source": [
     "from nustar_gen.radial_profile import find_source, make_radial_profile, optimize_radius_snr\n",
     "from nustar_gen.wrappers import make_image\n",
+    "from nustar_gen.io import write_ds9\n",
     "\n",
     "from astropy.wcs import WCS\n",
     "from astropy.io import fits\n",
     "from astropy.coordinates import SkyCoord\n",
     "import numpy as np\n",
     "\n",
-    "import regions\n",
     "import astropy.units as u"
    ]
   },
@@ -263,9 +263,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "source_reg = [regions.CircleSkyRegion(center=target, radius=60*u.arcsec)]\n",
     "outfile = 'example_data/30001039002/event_cl/srcA01.reg'\n",
-    "regions.write_ds9(source_reg, outfile, radunit='arcsec', overwrite=True)"
+    "write_ds9(target, outfile=outfile, rad = 60*u.arcsec)"
    ]
   },
   {
@@ -298,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/nustar_gen/io.py
+++ b/nustar_gen/io.py
@@ -76,7 +76,7 @@ def write_ds9(coord, rad=60*u.arcsec, outfile='ds9.reg'):
 
     rad : Astropy unit, default value: 60*u.arcsec
 
-    out_file : str, optional, default='ds9.reg'
+    outfile : str, optional, default='ds9.reg'
         Full path to the output region file
     
     

--- a/nustar_gen/io.py
+++ b/nustar_gen/io.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-
+import astropy.units as u
 
 def find_be_arf():
     '''
@@ -63,3 +63,31 @@ def find_arf_template():
     tempdir = os.path.join(curdir, 'templates')
     arf_file = os.path.join(tempdir, 'nu40101010002_srcA_sr.arf')
     return arf_file
+    
+def write_ds9(coord, rad=60*u.arcsec, outfile='ds9.reg'):
+    '''
+    Exports a ds9 region file for a circular extraction region
+    based on an Astropy coordinates object.
+    
+    Parameters
+    ----------
+    coord : Astropy Coordinates object
+        Coordinates for the source
+
+    rad : Astropy unit, default value: 60*u.arcsec
+
+    out_file : str, optional, default='ds9.reg'
+        Full path to the output region file
+    
+    
+    '''
+    fk5 = coord.fk5
+    with open(outfile, 'w') as f:
+        f.write('# Region file format: DS9\n')
+        f.write('fk5\n')
+        
+        regstring = f'circle({fk5.ra.deg}, {fk5.dec.deg}, {rad.to(u.arcsec).value}")\n'
+        f.write(regstring)
+
+    return    
+    


### PR DESCRIPTION
Required since astropy.regions changed their default syntax and their regions no longer work with nuproducts.