### PR TITLE
126 Notice: You are using astropy TestRunner that will be deprecated

### DIFF
--- a/nustar_gen/_astropy_init.py
+++ b/nustar_gen/_astropy_init.py
@@ -8,6 +8,3 @@ try:
 except ImportError:
     __version__ = ''
 
-# Create the test function for self test
-from astropy.tests.runner import TestRunner
-test = TestRunner.make_test_runner_in(os.path.dirname(__file__))


### PR DESCRIPTION
https://github.com/NuSTAR/nustar-gen-utils/issues/126

Closes #126

Removes astropy.tests. Note that we don't even pretend do to any runtime testing now or CI on this repo.
