### PR TITLE
125 Issue with GOES_example.ipynb

### DIFF
--- a/nustar_gen/diagnostic.py
+++ b/nustar_gen/diagnostic.py
@@ -54,15 +54,15 @@ def goes_lightcurve(obs, show_sun=False, show_sky=False, show_impact=True):
     tstart = (ns.met_to_time(hdr['TSTART']))
     tend = (ns.met_to_time(hdr['TSTOP']))
     
-    if tstart < Time('2019-01-01T01:00:00'):
-        gind = 15
-    else:
-        gind = 17
     
-    result = Fido.search(a.Time(tstart.fits, tend.fits), a.Instrument("XRS"),
-                        a.goes.SatelliteNumber(gind))
-    
-    files = Fido.fetch(result, progress=False)
+    result = Fido.search(a.Time(tstart.fits, tend.fits), a.Resolution('avg1m'),
+                         a.Instrument("XRS"))
+    satellites = result['xrs']['SatelliteNumber'].data
+    sat_id = np.unique(satellites).max()
+    result2 = Fido.search(a.Time(tstart.fits, tend.fits),a.Resolution('avg1m'),
+        a.Instrument("XRS"), a.goes.SatelliteNumber(sat_id))
+
+    files = Fido.fetch(result2, progress=False)
     goes_all = ts.TimeSeries(files, concatenate=True)
     goes = goes_all.truncate(tstart.iso, tend.iso)
 


### PR DESCRIPTION
Ckises #127 and #125

https://github.com/NuSTAR/nustar-gen-utils/issues/125
In the past, we could always use either GOES 15 or 17. GOES 17 had an issue and has been replaced by GOES 18.

Fixed this by now doing a SunPy Fido query over the time range of interest, figuring out what satellites are available, and then using the one with the highest number (assuming it'll always be the best in the case where you have both 16 and 18 or 15 and 17). Should (??) be future proof.
